### PR TITLE
Only depend on core library

### DIFF
--- a/Common.Logging.Elmah.v2/Common.Logging.Elmah.v2/Common.Logging.Elmah.v2.nuspec.template
+++ b/Common.Logging.Elmah.v2/Common.Logging.Elmah.v2/Common.Logging.Elmah.v2.nuspec.template
@@ -12,7 +12,7 @@
     <tags>elmah common logging adapter</tags>
     <dependencies>
       <dependency id="Common.Logging" />
-      <dependency id="elmah" />
+      <dependency id="elmah.corelibrary" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
The adapter should have only depend on the core library of Elmah, not configuration.
